### PR TITLE
Remove "-hwaccel auto"

### DIFF
--- a/crf24_hevc.bat
+++ b/crf24_hevc.bat
@@ -30,7 +30,7 @@ EXIT /B %ERRORLEVEL%
 :ffmpeg
     for /R %%A in (*.mp4, *.avi, *.mov, *.wmv, *.ts, *.m2ts, *.mkv, *.mts) do (
         echo Processing "%%A"
-        ffmpeg -hwaccel auto -i "%%A" -pix_fmt p010le -map 0:v -map 0:a -map_metadata 0 -c:v hevc_nvenc -rc constqp -qp %ffmpeg_qv% -b:v 0K -c:a aac -b:a 384k -movflags +faststart -movflags use_metadata_tags "%%A~dnpA_CRF%ffmpeg_qv%_HEVC.mp4"
+        ffmpeg -i "%%A" -pix_fmt p010le -map 0:v -map 0:a -map_metadata 0 -c:v hevc_nvenc -rc constqp -qp %ffmpeg_qv% -b:v 0K -c:a aac -b:a 384k -movflags +faststart -movflags use_metadata_tags "%%A~dnpA_CRF%ffmpeg_qv%_HEVC.mp4"
 		::"-pix_fmt p010le" is setting it to 10-bit instead of 420 8-bit, which is what I had before
 		:: "-map_metadata 0" copies all metadata from source file
 		:: "-movflags +faststart" helps with audio streaming


### PR DESCRIPTION
The "-hwaccel auto" configuration option is somewhat misunderstood in FFMPEG. This is NOT required to achieve hardware encoding with a supported driver/engine.

This flag, in its current position in the cli args list tells FFMPEG to attempt to use hardware acceleration for Decoding. The setting you have further down  specifying the video coded "-c:v hevc_nvenc" is what triggers hardware encoding to be enabled.

The effect of turning off hardware video decoding is, in theory, more gpu resources available for accelerated encoding. My own testing on a GTX 1660 resulted in a 2x encoding speedup when making this change. (1.1x realtime -> 2.15x realtime, on 4k content).

My GTX 2070 Super seems to have much less effect on encoding speed (6.8x to 7.2x, on 1080p), but it is still a slight improvement.

FFMPEG will fallback to cpu based video decoding with the above change, which is fine IMO because decoding is much less cpu intensive then encoding.

Have a test and see if you see similar results.