### PR TITLE
Set hwaccel to cuda

### DIFF
--- a/crf24_hevc.bat
+++ b/crf24_hevc.bat
@@ -1,4 +1,4 @@
-pushd "%2"
+pushd "%1"
 
 ::Default variables
 SET paths=paths.txt
@@ -9,7 +9,7 @@ SET /A ffmpeg_qv=24
 
 ::for /R %%A in (*.mp4, *.avi, *.mov, *.wmv, *.ts, *.m2ts, *.mkv, *.mts) do (
 ::    echo Processing %%A
-::    ffmpeg -hwaccel auto -i "%%A" -pix_fmt p010le -map 0:v -map 0:a -c:v hevc_nvenc -rc constqp -qp 21 -b:v 0K -c:a libfdk_aac -vbr 5 -movflags +faststart "%%A~dnpA_CRF%ffmpeg_qv%_HEVC.mp4"
+::    ffmpeg -hwaccel auto -i "%%A" -pix_fmt yuv420p -map 0:v -map 0:a -c:v hevc_nvenc -rc constqp -qp 21 -b:v 0K -c:a libfdk_aac -vbr 5 -movflags +faststart "%%~dpnA_CRF%ffmpeg_qv%_HEVC.mp4"
 ::    echo Processed %%A
 ::)
 ::pause
@@ -30,8 +30,8 @@ EXIT /B %ERRORLEVEL%
 :ffmpeg
     for /R %%A in (*.mp4, *.avi, *.mov, *.wmv, *.ts, *.m2ts, *.mkv, *.mts) do (
         echo Processing "%%A"
-        ffmpeg -hwaccel auto -i "%%A" -pix_fmt p010le -map 0:v -map 0:a -map_metadata 0 -c:v hevc_nvenc -rc constqp -qp %ffmpeg_qv% -b:v 0K -c:a aac -b:a 384k -movflags +faststart -movflags use_metadata_tags "%%A~dnpA_CRF%ffmpeg_qv%_HEVC.mp4"
-		::"-pix_fmt p010le" is setting it to 10-bit instead of 420 8-bit, which is what I had before
+        ffmpeg -hwaccel cuda -hwaccel_output_format cuda -i "%%A" -map 0:v -map 0:a -map_metadata 0 -c:v hevc_nvenc -bf 0 -rc constqp -qp %ffmpeg_qv% -b:v 0K -c:a aac -b:a 384k -movflags +faststart -movflags use_metadata_tags "%%~dpnA_CRF%ffmpeg_qv%_HEVC.mp4"
+		:: "-pix_fmt" can't be used together with "-hwaccel_output_format cuda"
 		:: "-map_metadata 0" copies all metadata from source file
 		:: "-movflags +faststart" helps with audio streaming
         echo Processed %%A


### PR DESCRIPTION
You can just change `auto` to `cuda` and `-pix_fmt` will still be usable. However it won't give the same effect. `-hwaccel_output_format cuda` is required from what I read and that can't be used with `-pix_fmt`. Maybe they can be used together but I couldn't figure it out. As for the `-bf 0`, I was getting "_No decoder surfaces left_" error when encoding starts. Some reddit thread said setting b-frames to 0 instead of default -1 (auto) OR using `-extra_hw_frames 2` (keep increasing 2 until error goes away) fixes it so I chose b-frame one. After doing these changes my speed went from 1.5-2x to 7.5-8x and gpu usage increased dramatically compared to original batch. Also used #4 to fix naming.